### PR TITLE
fix: prefer Buf::copy_to_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ async fn mpart(
 ) -> Result<impl warp::Reply, Infallible> {
     let boundary = mime.get_param("boundary").map(|v| v.to_string()).unwrap();
 
-    let mut stream = MultipartStream::new(boundary, body.map_ok(|mut buf| buf.to_bytes()));
+    let mut stream = MultipartStream::new(
+        boundary,
+        body.map_ok(|buf| buf.copy_to_bytes(buf.remaining())),
+    );
 
     while let Ok(Some(mut field)) = stream.try_next().await {
         println!("Field received:{}", field.name().unwrap());

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,6 +1,6 @@
 use warp::Filter;
 
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::Buf;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
 use mime::Mime;
@@ -24,11 +24,10 @@ async fn mpart(
 ) -> Result<impl warp::Reply, Infallible> {
     let boundary = mime.get_param("boundary").map(|v| v.to_string()).unwrap();
 
-    let mut stream = MultipartStream::new(boundary, body.map_ok(|buf| {
-        let mut ret = BytesMut::with_capacity(buf.remaining());
-        ret.put(buf);
-        ret.freeze()
-    }));
+    let mut stream = MultipartStream::new(
+        boundary,
+        body.map_ok(|mut buf| buf.copy_to_bytes(buf.remaining())),
+    );
 
     while let Ok(Some(mut field)) = stream.try_next().await {
         println!("Field received:{}", field.name().unwrap());

--- a/src/filestream.rs
+++ b/src/filestream.rs
@@ -70,9 +70,7 @@ mod tests {
 
     #[tokio::test]
     async fn streams_file() -> Result<(), Error> {
-        let bytes = FileStream::new("Cargo.toml")
-            .next()
-            .await.unwrap()?;
+        let bytes = FileStream::new("Cargo.toml").next().await.unwrap()?;
 
         assert_eq!(bytes, &include_bytes!("../Cargo.toml")[..]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! ```no_run
 //! use warp::Filter;
 //!
-//! use bytes::{Buf, BufMut, BytesMut};
+//! use bytes::Buf;
 //! use futures_util::TryStreamExt;
 //! use futures_core::Stream;
 //! use mime::Mime;
@@ -89,11 +89,10 @@
 //! ) -> Result<impl warp::Reply, Infallible> {
 //!     let boundary = mime.get_param("boundary").map(|v| v.to_string()).unwrap();
 //!
-//!     let mut stream = MultipartStream::new(boundary, body.map_ok(|mut buf| {
-//!         let mut ret = BytesMut::with_capacity(buf.remaining());
-//!         ret.put(buf);
-//!         ret.freeze()
-//!     }));
+//!     let mut stream = MultipartStream::new(
+//!         boundary,
+//!         body.map_ok(|mut buf| buf.copy_to_bytes(buf.remaining())),
+//!     );
 //!
 //!     while let Ok(Some(mut field)) = stream.try_next().await {
 //!         println!("Field received:{}", field.name().unwrap());


### PR DESCRIPTION
Prefer Buf::copy_to_bytes instead of allocating a new BytesMut.